### PR TITLE
Patch 6

### DIFF
--- a/examples/P1P2json-mega/P1P2json-mega.ino
+++ b/examples/P1P2json-mega/P1P2json-mega.ino
@@ -53,11 +53,6 @@ IPAddress gateway(192, 168, 1, 1);
 IPAddress subnet(255, 255, 255, 0);
 IPAddress sendIpAddress(255, 255, 255, 255);                      // remote IP or 255, 255, 255, 255 for broadcast (faster)
 
-#define inputPacketBufferSize UDP_TX_PACKET_MAX_SIZE
-char inputPacketBuffer[UDP_TX_PACKET_MAX_SIZE];
-#define outputPacketBufferSize 100
-char outputPacketBuffer[outputPacketBufferSize];
-
 EthernetUDP udpRecv;                                              // for future functionality....
 EthernetUDP udpSend;
 


### PR DESCRIPTION
Thanks, "changeonly" now works perfectly. 

Adding UDP functionality is in principle quite straightforward.

But....

JSON documents are too long if I include unknown parameters. To be more precise, it seems that long JSON document is split into several UDP messages, maximum 1472 bytes.

Would it be possible to terminate JSON after each packet? For example after each CRC check? At the moment, JSON is terminated only after full package.