### PR TITLE
add needed returns for non-void functions

### DIFF
--- a/examples/P1P2-bridge-esp8266/P1P2_Daikin_ParameterConversion_EHYHB.h
+++ b/examples/P1P2-bridge-esp8266/P1P2_Daikin_ParameterConversion_EHYHB.h
@@ -575,6 +575,7 @@ uint8_t param_value_s_BE(byte paramSrc, byte paramPacketType, uint16_t paramNr, 
   } else {
     snprintf(mqtt_value, MQTT_VALUE_LEN, "%i", v);
   }
+  return 1;
 }
 
 // Parameters, unsigned, LE
@@ -613,6 +614,7 @@ uint8_t param_value_s_LE(byte paramSrc, byte paramPacketType, uint16_t paramNr, 
   } else {
     snprintf(mqtt_value, MQTT_VALUE_LEN, "%i", v);
   }
+  return 1;
 }
 
 // u16div10, s16div10 LE


### PR DESCRIPTION
I didn't do much of a review to see if this is the right return value but as a non-void function it shoudl return something.  Arduino IDE clearly assumes some sort of default, but platformio will throw an error if there isn't a return for all cases of the function